### PR TITLE
Fix visitor map and refresh homepage sections

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -10,6 +10,11 @@
 ## Plans Index (active/recent — see `SESSION-LOG-ARCHIVE.md` for earlier plans)
 | Date | Plan | Epic | Status | Notes |
 |------|------|------|--------|-------|
+| 2026-07-22 | [remove-feedback-4-7](plans/2026-07-22-05-remove-feedback-4-7.md) | E0 | done | Removed the Constructive Guidance 4.7/5 card and retained only the three selected 4.8/5 indicators. |
+| 2026-07-22 | [collapsible-supervision](plans/2026-07-22-04-collapsible-supervision.md) | E0 | done | Converted Current and Alumni into native collapsible groups with entry counts; Current opens by default and Alumni starts closed. |
+| 2026-07-22 | [ruijun-feng-supervision](plans/2026-07-22-03-ruijun-feng-supervision.md) | E0 | done | Added Ruijun Feng as a current PhD student at UNSW immediately after Penghao Jiang. |
+| 2026-07-22 | [hide-tools-section](plans/2026-07-22-02-hide-tools-section.md) | E0 | done | Commented out the Tools navigation and section without deleting them; shifted Education, Awards, and Misc backgrounds to preserve alternation. |
+| 2026-07-22 | [visitor-map-unknown-location](plans/2026-07-22-01-visitor-map-unknown-location.md) | E0 | done | Identified `[28, -68]` as MapMyVisitors' `unknown location` placeholder, filtered it, and replaced misleading live wording with geolocated-record wording. |
 | 2026-07-19 | [merged-visitor-map](plans/2026-07-19-13-merged-visitor-map.md) | E0 | done | Replaced the two-map footer with one archived historical map plus live green coordinate overlays and graceful failure behavior. |
 | 2026-07-19 | [live-visitor-map](plans/2026-07-19-12-live-visitor-globe.md) | E0 | done | Introduced the replacement live dataset and visible archive; its interim two-card layout was superseded by the merged-map plan. |
 | 2026-07-19 | [supervision-additions](plans/2026-07-19-11-supervision-additions.md) | E0 | done | Added Thanakit Rattikanchalakorn to Current and Jianing Wang to Alumni with their supplied status details. |
@@ -26,13 +31,14 @@
 | 2026-07-02 | [scaffolding](plans/2026-07-02-01-scaffolding.md) | E0 | done | **LDD bootstrap complete.** Added `docs/PROGRESS.md` and `docs/plans/2026-07-02-01-scaffolding.md`. Project is a plain static GitHub Pages site; no build/test pipeline exists. |
 
 ## Next Steps
-- **Immediate:** Monitor the published merged visitor map to confirm live green locations continue updating alongside the preserved historical dots.
+- **Immediate:** Publish all scoped homepage and feedback-page changes in the prepared branch, then verify the draft PR.
 - **Before any future code/content change:** Create a new dated plan under `docs/plans/` and add it to this index.
 - **Likely next useful plan:** Add a lightweight static-site verification workflow for HTML/link checks and manual browser smoke testing.
 - **Content update reminder:** When publications change, update both the selected and full publication lists, any linked `bibs/*.html` entry, relevant `data/` PDFs, and the news section if applicable.
 
 ## Known Issues
-- The original ClustrMaps domain remains unavailable, and its raw dataset cannot be imported into MapMyVisitors. The footer performs a presentation-layer merge instead: the archived record through 23 February 2026 remains the map base, with live MapMyVisitors coordinates since 19 July 2026 overlaid in green. Provider-side counts remain separate.
+- The original ClustrMaps domain remains unavailable, and its raw dataset cannot be imported into MapMyVisitors. The footer performs a presentation-layer merge instead: the archived record through 23 February 2026 remains the map base, with genuinely geolocated MapMyVisitors coordinates recorded since 19 July 2026 overlaid in green. Provider-side counts remain separate.
+- MapMyVisitors currently reports all replacement-dataset visits as `unknown location` at its fixed `[28, -68]` placeholder and exposes no nonzero incremental hit ID. The page now suppresses that false marker and will show green markers only when the provider supplies real coordinates; truly real-time online-presence tracking is not available from this static third-party widget.
 - No automated validation currently exists for internal links, external links, or HTML consistency; verify manually after content updates.
 - Publication metadata is duplicated across selected and full lists in `index.html`, so updates can drift unless both places are checked.
 
@@ -46,6 +52,31 @@
 | LDD | Keep durable project state in `docs/PROGRESS.md`; create a dated plan before future implementation or content edits. |
 
 ## Session Log
+
+### 2026-07-22
+- **Focus:** COMP3050 feedback-rating refinement.
+- **Completed:** Removed the Constructive Guidance 4.7/5 card and all public mention of that score; retained the three selected 4.8/5 indicator cards and updated the method note accordingly.
+- **Tests:** Confirmed exactly three rating cards, all at 4.8/5; confirmed neither `4.7` nor `Constructive guidance` remains in the page; `git diff --check` passed.
+- **Files:** `html/comp3050-feedback-2026s1.html`, `docs/plans/2026-07-22-05-remove-feedback-4-7.md`, `docs/PROGRESS.md`.
+- **Blockers:** None.
+
+- **Focus:** Collapsible supervision presentation.
+- **Completed:** Converted Current and Alumni into independent native disclosure controls with visible counts; kept Current expanded and Alumni collapsed by default; preserved all 19 entries and Ruijun Feng's requested ordering.
+- **Tests:** Confirmed two disclosure groups, default open/closed states, Current/Alumni counts of 13/6, Ruijun Feng ordering, inline JavaScript syntax, and `git diff --check`.
+- **Files:** `index.html`, `docs/plans/2026-07-22-04-collapsible-supervision.md`, `docs/PROGRESS.md`.
+- **Blockers:** None.
+
+- **Focus:** Current supervision addition.
+- **Completed:** Added Ruijun Feng as a PhD student at UNSW immediately after Penghao Jiang; the Current list now contains 13 entries.
+- **Tests:** Confirmed the entry occurs exactly once and is ordered between Penghao Jiang and Jiawei Wang; inline JavaScript syntax and `git diff --check` passed.
+- **Files:** `index.html`, `docs/plans/2026-07-22-03-ruijun-feng-supervision.md`, `docs/PROGRESS.md`.
+- **Blockers:** None.
+
+- **Focus:** False visitor-map marker correction and temporary Tools-section removal.
+- **Completed:** Confirmed the persistent `[28, -68]` point is MapMyVisitors' `unknown location` placeholder rather than a North American visitor; changed marker parsing to retain labels and suppress unknown locations; replaced `Live` wording with accurate recorded/geolocated wording and a zero-location state while preserving 30-second refresh for valid future coordinates. Commented out the Tools navigation and full section without deleting them, then shifted downstream backgrounds to retain white/grey alternation.
+- **Tests:** The current provider payload contained one unknown marker and zero geolocated markers; a DOM simulation rejected that placeholder and rendered a valid Sydney coordinate; inline JavaScript syntax passed; active HTML after comment removal contains no Tools link/section; HTML comment counts balance; local homepage returned HTTP 200; `git diff --check` passed.
+- **Files:** `index.html`, `docs/plans/2026-07-22-01-visitor-map-unknown-location.md`, `docs/plans/2026-07-22-02-hide-tools-section.md`, `docs/PROGRESS.md`.
+- **Blockers:** MapMyVisitors currently supplies no real geolocation for this dataset, so the page cannot show a green point until the provider records a mappable visit.
 
 ### 2026-07-19
 - **Focus:** Single-map historical/live visitor merge.

--- a/docs/plans/2026-07-22-01-visitor-map-unknown-location.md
+++ b/docs/plans/2026-07-22-01-visitor-map-unknown-location.md
@@ -1,0 +1,42 @@
+# Plan: Remove the False Live Visitor Marker
+
+**Epic:** E0: Site Maintenance Baseline
+
+## Summary
+
+Correct the merged visitor map so MapMyVisitors' fixed `unknown location` placeholder is not presented as a real-time visitor in North America. Keep polling for genuinely geolocated visits, but describe the third-party data as recently recorded locations rather than current online visitors.
+
+**Decisions locked in:**
+- Preserve the archived historical map and existing MapMyVisitors dataset.
+- Reject provider markers explicitly labelled `unknown location` instead of filtering by coordinates alone.
+- Keep periodic refresh for valid new coordinates and retain graceful failure behavior.
+
+---
+
+## Phase 1: Correct Marker Semantics
+
+### [x] Task 1.1: Filter provider placeholders
+- [x] In `index.html`, parse complete marker objects so their provider labels remain available.
+- [x] Exclude markers whose label identifies them as an unknown location.
+
+### [x] Task 1.2: Make the status and legend accurate
+- [x] Replace the misleading `Live` legend with wording for provider-recorded, geolocated visits.
+- [x] Show a clear no-geolocated-visits state when the provider only returns placeholders.
+- [x] Continue refreshing without presenting a provider placeholder as a real visitor.
+
+## Phase 2: Verify and Document
+
+### [x] Task 2.1: Verify the correction
+- [x] Test the parser against the current provider payload containing `{latLng: [28, -68], name: "12 visits from unknown location"}`.
+- [x] Test valid-coordinate rendering and no-location behavior in a DOM simulation.
+- [x] Check inline JavaScript syntax, local HTTP response, and `git diff --check`.
+
+### [x] Task 2.2: Close the LDD session
+- [x] Mark plan tasks complete and update `docs/PROGRESS.md` with outcome, verification, files, and blockers.
+
+## Verification
+- [x] The `[28, -68]` unknown-location placeholder is not rendered.
+- [x] Valid geolocated markers still render and refresh.
+- [x] The page no longer implies that accumulated provider markers are currently online.
+- [x] `git diff --check` passes.
+- [x] `docs/PROGRESS.md` is updated with results.

--- a/docs/plans/2026-07-22-02-hide-tools-section.md
+++ b/docs/plans/2026-07-22-02-hide-tools-section.md
@@ -1,0 +1,40 @@
+# Plan: Hide the Homepage Tools Section
+
+**Epic:** E0: Site Maintenance Baseline
+
+## Summary
+
+Temporarily hide the homepage Tools section without deleting its content. Comment out both the section and its navigation link, then shift downstream section backgrounds so the visible layout continues to alternate.
+
+**Decisions locked in:**
+- Preserve the Tools HTML inside comments for easy restoration.
+- Do not leave a sidebar link pointing to a hidden anchor.
+- Keep visible homepage sections alternating between white and light grey.
+
+---
+
+## Phase 1: Hide Tools
+
+### [x] Task 1.1: Comment out Tools markup
+- [x] In `index.html`, comment out the Tools sidebar navigation link.
+- [x] Comment out the complete Tools content section without deleting it.
+
+### [x] Task 1.2: Preserve visible section alternation
+- [x] Shift the Education, Grants & Awards, and Misc background classes after hiding Tools.
+
+## Phase 2: Verify and Document
+
+### [x] Task 2.1: Verify the homepage
+- [x] Confirm there is no active `#tools` navigation link or visible `id="tools"` section.
+- [x] Confirm the Tools content remains recoverable in HTML comments.
+- [x] Check local HTTP response and `git diff --check`.
+
+### [x] Task 2.2: Close the LDD session
+- [x] Mark tasks complete and update `docs/PROGRESS.md` with results.
+
+## Verification
+- [x] Tools is absent from the rendered navigation and page.
+- [x] Tools source content remains commented in `index.html`.
+- [x] Visible section backgrounds alternate correctly.
+- [x] `git diff --check` passes.
+- [x] `docs/PROGRESS.md` is updated with results.

--- a/docs/plans/2026-07-22-03-ruijun-feng-supervision.md
+++ b/docs/plans/2026-07-22-03-ruijun-feng-supervision.md
@@ -1,0 +1,32 @@
+# Plan: Add Ruijun Feng to Supervision
+
+**Epic:** E0: Site Maintenance Baseline
+
+## Summary
+
+Add Ruijun Feng to the homepage Current supervision list as a PhD student at UNSW, immediately after Penghao Jiang.
+
+**Decisions locked in:**
+- Use the existing supervision-entry wording and `<strong>` name formatting.
+- Preserve the user-specified ordering after Penghao Jiang.
+
+---
+
+## Phase 1: Update Supervision
+
+### [x] Task 1.1: Add the student entry
+- [x] In `index.html`, add `Ruijun Feng (PhD at UNSW)` immediately after Penghao Jiang.
+
+## Phase 2: Verify and Document
+
+### [x] Task 2.1: Verify the update
+- [x] Confirm Ruijun Feng appears exactly once in Supervision and directly follows Penghao Jiang.
+- [x] Check inline JavaScript syntax and `git diff --check`.
+
+### [x] Task 2.2: Close the LDD session
+- [x] Mark tasks complete and update `docs/PROGRESS.md` with results.
+
+## Verification
+- [x] Correct name, degree, institution, formatting, and ordering.
+- [x] `git diff --check` passes.
+- [x] `docs/PROGRESS.md` is updated with results.

--- a/docs/plans/2026-07-22-04-collapsible-supervision.md
+++ b/docs/plans/2026-07-22-04-collapsible-supervision.md
@@ -1,0 +1,41 @@
+# Plan: Make Supervision Collapsible
+
+**Epic:** E0: Site Maintenance Baseline
+
+## Summary
+
+Make the Current and Alumni supervision groups independently collapsible so the homepage remains compact while keeping every student entry accessible.
+
+**Decisions locked in:**
+- Use native HTML `<details>` and `<summary>` controls for accessible, dependency-free behavior.
+- Show entry counts in both group labels.
+- Keep Current expanded by default and Alumni collapsed by default.
+
+---
+
+## Phase 1: Add Collapsible Groups
+
+### [x] Task 1.1: Add disclosure markup
+- [x] In `index.html`, wrap the Current list in an open disclosure labelled `Current (13)`.
+- [x] Wrap the Alumni list in a closed disclosure labelled `Alumni (6)`.
+
+### [x] Task 1.2: Style the controls
+- [x] Add compact summary and disclosure spacing consistent with the existing site typography.
+- [x] Keep the controls keyboard-accessible and understandable without JavaScript.
+
+## Phase 2: Verify and Document
+
+### [x] Task 2.1: Verify behavior and content
+- [x] Confirm both groups use valid native disclosure markup with the intended default states.
+- [x] Confirm Current and Alumni retain 13 and 6 entries respectively.
+- [x] Check inline JavaScript syntax and `git diff --check`.
+
+### [x] Task 2.2: Close the LDD session
+- [x] Mark tasks complete and update `docs/PROGRESS.md` with results.
+
+## Verification
+- [x] Current is expanded by default and Alumni is collapsed by default.
+- [x] Both groups can be toggled without JavaScript.
+- [x] All student entries and ordering are preserved.
+- [x] `git diff --check` passes.
+- [x] `docs/PROGRESS.md` is updated with results.

--- a/docs/plans/2026-07-22-05-remove-feedback-4-7.md
+++ b/docs/plans/2026-07-22-05-remove-feedback-4-7.md
@@ -1,0 +1,36 @@
+# Plan: Remove the 4.7 Feedback Highlight
+
+**Epic:** E0: Site Maintenance Baseline
+
+## Summary
+
+Remove the Constructive Guidance 4.7/5 card and all public mention of that score from the COMP3050 feedback highlights page. Retain the three selected teaching indicators that each received 4.8/5.
+
+**Decisions locked in:**
+- Remove the entire Constructive Guidance card rather than merely hiding its number.
+- Keep the privacy/method note concise and state only that the displayed indicator groups received 4.8/5.
+- Preserve the remaining ratings, response rate, and paraphrased positive themes.
+
+---
+
+## Phase 1: Refine the Feedback Page
+
+### [x] Task 1.1: Remove the lower rating
+- [x] In `html/comp3050-feedback-2026s1.html`, remove the Constructive Guidance card.
+- [x] Remove every public occurrence of `4.7` and update the method note for the three displayed 4.8 groups.
+
+## Phase 2: Verify and Document
+
+### [x] Task 2.1: Verify the page
+- [x] Confirm the page contains three rating cards, each displaying 4.8/5.
+- [x] Confirm neither `4.7` nor `Constructive guidance` remains in the public page.
+- [x] Check local HTML response and `git diff --check`.
+
+### [x] Task 2.2: Close the LDD session
+- [x] Mark tasks complete and update `docs/PROGRESS.md` with results.
+
+## Verification
+- [x] Only three 4.8/5 teaching indicators are shown.
+- [x] No public mention of the 4.7 score remains.
+- [x] `git diff --check` passes.
+- [x] `docs/PROGRESS.md` is updated with results.

--- a/html/comp3050-feedback-2026s1.html
+++ b/html/comp3050-feedback-2026s1.html
@@ -137,11 +137,6 @@
         <p>Intellectual engagement, commitment, subject knowledge, enthusiasm, motivation, and preparation.</p>
       </article>
 
-      <article class="rating-card">
-        <h3>Constructive guidance</h3>
-        <p class="score">4.7 <small>/ 5</small></p>
-        <p>Constructive suggestions that helped students improve their work.</p>
-      </article>
     </div>
 
     <h2>Recurring positive themes</h2>
@@ -156,7 +151,7 @@
     </section>
 
     <aside class="note">
-      <strong>Privacy and method note.</strong> This page presents selected aggregate results and paraphrased themes from the anonymous Learner Experience of Tutorial survey. The internal evaluation report, demographic information, and response-level comments are not published. Category scores reflect the reported mean for their associated survey items; all grouped items shown above received 4.8 except constructive guidance, which received 4.7.
+      <strong>Privacy and method note.</strong> This page presents selected aggregate results and paraphrased themes from the anonymous Learner Experience of Tutorial survey. The internal evaluation report, demographic information, and response-level comments are not published. The three displayed indicator groups each received 4.8/5.
     </aside>
 
     <p class="footer-link"><a href="../index.html#teaching">&larr; Back to Teaching Experience</a></p>

--- a/index.html
+++ b/index.html
@@ -145,6 +145,32 @@
     font-size: 11px;
   }
 
+  .supervision-group {
+    margin: 6px 0 10px;
+  }
+
+  .supervision-group summary {
+    width: fit-content;
+    padding: 3px 0;
+    cursor: pointer;
+    font-size: 18px;
+    font-weight: 500;
+  }
+
+  .supervision-group summary::marker {
+    color: #7b848c;
+  }
+
+  .supervision-group-count {
+    color: #7b848c;
+    font-size: 13px;
+    font-weight: 400;
+  }
+
+  .supervision-group ul {
+    margin-top: 5px;
+  }
+
   .site-credit {
     margin: 12px 0 0;
     color: #8a929a;
@@ -176,7 +202,7 @@
     <a href="#service" class="w3-bar-item w3-button">Services</a>
     <a href="#teaching" class="w3-bar-item w3-button">Teaching</a>
     <a href="#supervision" class="w3-bar-item w3-button">Supervision</a>
-    <a href="#tools" class="w3-bar-item w3-button">Tools</a>
+    <!-- <a href="#tools" class="w3-bar-item w3-button">Tools</a> -->
     <a href="#edu" class="w3-bar-item w3-button">Education</a>
     <a href="#award" class="w3-bar-item w3-button">Grants & Awards</a>
     <a href="#misc" class="w3-bar-item w3-button">Misc</a>
@@ -420,34 +446,39 @@
   <!-- The Supervision Section -->
   <div class="w3-container" id="supervision" style="padding-bottom: 10px">
     <h3>Supervision</h3>
-    <h4>Current</h4>
-    <ul style="padding-left: 2em;">
-      <li><strong>Mingxiu Wang</strong> (MRes at MQ).</li>
-      <li><strong>Weixian Qian</strong> (PhD at MQ).</li>
-      <li><strong>Suhaas Gambhir</strong> (MRes + PhD at MQ).</li>
-      <li><strong>Debashish Kumar</strong> (MRes at MQ).</li>
-      <li><strong>Zexin Zhong</strong> (PhD at UTS).</li>
-      <li><strong>Weigang He</strong> (PhD at UTS).</li>
-      <li><strong>Penghao Jiang</strong> (PhD at UNSW).</li>
-      <li><strong>Jiawei Wang</strong> (PhD at UNSW).</li>
-      <li><strong>Jiawei Yang</strong> (PhD at UNSW).</li>
-      <li><strong>Shangzhi Xu</strong> (PhD at UNSW + Data'61).</li>
-      <li><strong>Zhihao Guo</strong> (PhD at UTS).</li>
-      <li><strong>Thanakit Rattikanchalakorn</strong> (Summer Research Student).</li>
-    </ul>
+    <details class="supervision-group" open>
+      <summary>Current <span class="supervision-group-count">(13)</span></summary>
+      <ul style="padding-left: 2em;">
+        <li><strong>Mingxiu Wang</strong> (MRes at MQ).</li>
+        <li><strong>Weixian Qian</strong> (PhD at MQ).</li>
+        <li><strong>Suhaas Gambhir</strong> (MRes + PhD at MQ).</li>
+        <li><strong>Debashish Kumar</strong> (MRes at MQ).</li>
+        <li><strong>Zexin Zhong</strong> (PhD at UTS).</li>
+        <li><strong>Weigang He</strong> (PhD at UTS).</li>
+        <li><strong>Penghao Jiang</strong> (PhD at UNSW).</li>
+        <li><strong>Ruijun Feng</strong> (PhD at UNSW).</li>
+        <li><strong>Jiawei Wang</strong> (PhD at UNSW).</li>
+        <li><strong>Jiawei Yang</strong> (PhD at UNSW).</li>
+        <li><strong>Shangzhi Xu</strong> (PhD at UNSW + Data'61).</li>
+        <li><strong>Zhihao Guo</strong> (PhD at UTS).</li>
+        <li><strong>Thanakit Rattikanchalakorn</strong> (Summer Research Student).</li>
+      </ul>
+    </details>
 
-    <h4>Alumni</h4>
-    <ul style="padding-left: 2em;">
-      <li><strong>Haodong Li</strong> (PhD at BUPT).</li>
-      <li><strong>Shuangxiang Kan</strong> (PhD at UNSW, now Postdoc at SMU).</li>
-      <li><strong>Jiawei Ren</strong> (PhD at UNSW).</li>
-      <li><strong>Jiahao Zhang</strong> (MPhil at UNSW).</li>
-      <li><strong>Linfeng Liang</strong> (PhD at MQ).</li>
-      <li><strong>Jianing Wang</strong> (Undergraduate student, now PhD at Monash).</li>
-    </ul>
+    <details class="supervision-group">
+      <summary>Alumni <span class="supervision-group-count">(6)</span></summary>
+      <ul style="padding-left: 2em;">
+        <li><strong>Haodong Li</strong> (PhD at BUPT).</li>
+        <li><strong>Shuangxiang Kan</strong> (PhD at UNSW, now Postdoc at SMU).</li>
+        <li><strong>Jiawei Ren</strong> (PhD at UNSW).</li>
+        <li><strong>Jiahao Zhang</strong> (MPhil at UNSW).</li>
+        <li><strong>Linfeng Liang</strong> (PhD at MQ).</li>
+        <li><strong>Jianing Wang</strong> (Undergraduate student, now PhD at Monash).</li>
+      </ul>
+    </details>
   </div>
 
-  <!-- The Tool Section -->
+  <!-- The Tool Section (temporarily hidden)
   <div class="w3-container w3-light-grey" id="tools" style="padding-bottom: 10px">
     <h3>Tools</h3>
     <ul style="padding-left: 2em;">
@@ -455,9 +486,10 @@
      <li> Creator, <a href="https://github.com/jumormt/DeepWukong">DeepWukong</a><img src="https://img.shields.io/github/stars/jumormt/DeepWukong">, a graph neural network based software vulnerability detector.</li>
     </ul>
   </div>
+  -->
 
   <!-- The Education Section -->
-  <div class="w3-container" id="edu" style="padding-bottom: 10px">
+  <div class="w3-container w3-light-grey" id="edu" style="padding-bottom: 10px">
     <h3>Education</h3>
     <ul style="padding-left: 2em;">
     <li> 2021-2024, Ph.D. in Computer Science and Engineering, <a href="https://www.unsw.edu.au/homepage/">University of New South Wales (UNSW)</a>.
@@ -466,7 +498,7 @@
   </div>  
 
   <!-- The Awards Section -->
-  <div class="w3-container w3-light-grey" id="award" style="padding-bottom: 10px">
+  <div class="w3-container" id="award" style="padding-bottom: 10px">
     <h3>Grants & Awards</h3>
     <ul style="padding-left: 2em;">
 	  <li>2026, <a href="https://pldi26.sigplan.org/track/pldi-2026-pldi-research-artifacts">PLDI 2026 Distinguished Artifact Evaluation Reviewer Award</a>.</li>
@@ -487,7 +519,7 @@
 
 
   <!-- The Misc Section -->
-  <div class="w3-container" id="misc" style="padding-bottom: 10px">
+  <div class="w3-container w3-light-grey" id="misc" style="padding-bottom: 10px">
     <h3>Misc</h3>
     <ul style="padding-left: 2em;">
     <li> <a href="http://www.cs.wisc.edu/wpis/talks/WritingResearchPapers.pptx">Tips on writing a research paper</a>, <a href="data/research-tips-zhendongsu.pdf">Doing Research in Software Analysis Lessons and Tips</a>.</li>
@@ -504,18 +536,18 @@
 
       <div class="visitor-map-card">
         <a class="visitor-merged-map" href="https://web.archive.org/web/20260223125538/https://clustrmaps.com/map_v2.png?d=HA1rasF4Ps-g80mwIHPsyroDFlKH7oDfpAJDT-R0J8U&amp;cl=ffffff" title="Open the preserved historical visitor map">
-          <img src="https://web.archive.org/web/20260223125538id_/https://clustrmaps.com/map_v2.png?d=HA1rasF4Ps-g80mwIHPsyroDFlKH7oDfpAJDT-R0J8U&amp;cl=ffffff" alt="Visitor map with historical locations through 23 February 2026 and live locations since 19 July 2026">
+          <img src="https://web.archive.org/web/20260223125538id_/https://clustrmaps.com/map_v2.png?d=HA1rasF4Ps-g80mwIHPsyroDFlKH7oDfpAJDT-R0J8U&amp;cl=ffffff" alt="Visitor map with historical locations through 23 February 2026 and geolocated visits recorded since 19 July 2026">
           <div class="visitor-live-layer" id="visitor-live-layer" aria-hidden="true"></div>
         </a>
 
         <div class="visitor-map-legend" aria-label="Visitor map legend">
           <span><i class="visitor-legend-dot is-history" aria-hidden="true"></i>Historical</span>
-          <span><i class="visitor-legend-dot is-live" aria-hidden="true"></i>Live</span>
+          <span><i class="visitor-legend-dot is-live" aria-hidden="true"></i>Since Jul 2026</span>
         </div>
       </div>
 
-      <p class="visitor-map-status" id="visitor-map-status">
-        Historical through 23 February 2026 &middot; <a href="https://mapmyvisitors.com/web/1c6os">live since 19 July 2026</a>
+      <p class="visitor-map-status" id="visitor-map-status" aria-live="polite">
+        Historical through 23 February 2026 &middot; checking recent locations
       </p>
 
       <span id="busuanzi_container_site_pv" style="display:none">
@@ -573,7 +605,7 @@ new Vue({
 
   function showLiveUnavailable() {
     status.classList.add("is-error");
-    status.innerHTML = "Historical record shown &middot; live layer temporarily unavailable";
+    status.innerHTML = "Historical record shown &middot; recent location data temporarily unavailable";
   }
 
   function renderLocations() {
@@ -593,17 +625,25 @@ new Vue({
     });
 
     status.classList.remove("is-error");
+    if (!coordinates.length) {
+      status.innerHTML = "Historical through 23 February 2026 &middot; "
+        + "<a href=\"https://mapmyvisitors.com/web/1c6os\">no geolocated visits recorded yet</a>";
+      return;
+    }
+
     status.innerHTML = "Historical through 23 February 2026 &middot; "
       + "<a href=\"https://mapmyvisitors.com/web/1c6os\">"
-      + coordinates.length + " live location" + (coordinates.length === 1 ? "" : "s")
-      + " since 19 July 2026</a>";
+      + coordinates.length + " geolocated visitor location" + (coordinates.length === 1 ? "" : "s")
+      + " recorded since 19 July 2026</a>";
   }
 
   function collectLocations(source) {
-    var coordinatePattern = /latLng:\s*\[\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\]/g;
+    var coordinatePattern = /latLng:\s*\[\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\]\s*,\s*name:\s*"([^"]*)"/g;
     var match;
 
     while ((match = coordinatePattern.exec(source)) !== null) {
+      if (/unknown location/i.test(match[3])) continue;
+
       locations[match[1] + "," + match[2]] = {
         latitude: Number(match[1]),
         longitude: Number(match[2])
@@ -652,7 +692,7 @@ new Vue({
     initialHitId = initialHitMatch[1];
     lastHitId = lastHitMatch[1];
     collectLocations(source);
-    if (Object.keys(locations).length) renderLocations();
+    renderLocations();
     requestLiveMarkers(true);
   };
 


### PR DESCRIPTION
## What changed

- Filter MapMyVisitors' fixed `unknown location` placeholder and use accurate geolocated-visit wording.
- Hide the Tools navigation and section while preserving the source.
- Add Ruijun Feng to Current supervision.
- Make Current and Alumni native collapsible groups with entry counts.
- Remove the Constructive Guidance 4.7/5 card and all public mention of that score.
- Record the work in LDD plans and progress.

## Why

The provider's `[28, -68]` placeholder was being mistaken for a live North American visitor. The other updates make the homepage more compact and align the supervision and feedback content with the requested presentation.

## Validation

- Homepage and feedback page returned HTTP 200 locally.
- The unknown visitor placeholder was filtered while a valid Sydney coordinate rendered in simulation.
- Current/Alumni disclosure states and counts verified as 13/6.
- Tools markup is absent from rendered HTML.
- The feedback page contains three 4.8/5 cards and no 4.7 mention.
- Inline JavaScript syntax and `git diff --check` passed.
